### PR TITLE
Add support for api_list serialization.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-    - 7.1
     - 7.2
+    - 7.3
 
 before_script:
     - curl -s http://getcomposer.org/installer | php

--- a/src/Listener/ContentNegotiationListener.php
+++ b/src/Listener/ContentNegotiationListener.php
@@ -49,10 +49,15 @@ class ContentNegotiationListener
             /** @var Accept $accept */
             $accept = $this->negotiator->getBest($request->headers->get('Accept'), $this->priorities);
 
+            $groups = interface_exists('Knp\Component\Pager\Pagination\PaginationInterface') && $result instanceof \Knp\Component\Pager\Pagination\PaginationInterface
+                ? [ 'api_list']
+                : [ 'api' ]
+            ;
+
             switch ($accept->getType())
             {
                 case 'application/xml':
-                    $response = new Response($this->serializer->serialize($result, 'xml', ['groups' => ['api']]));
+                    $response = new Response($this->serializer->serialize($result, 'xml', [ 'groups' => $groups ]));
                     break;
 
                 case 'text/html':
@@ -60,7 +65,7 @@ class ContentNegotiationListener
                     break;
 
                 default:
-                    $response = new Response($this->serializer->serialize($result, 'json', ['groups' => ['api']]));
+                    $response = new Response($this->serializer->serialize($result, 'json', [ 'groups' => $groups ]));
             }
 
             $response->headers->add(['Content-Type' => $accept->getType()]);


### PR DESCRIPTION
if you have a document

```yaml
App\Document\Task:
  attributes:
    id:
      groups: [ 'api', 'api_list' ]
    name:
      groups: [ 'api', 'api_list' ]
    details:
      groups: [ 'api']
```

and you return instance of `Knp\Component\Pager\Pagination\PaginationInterface` in the controller,
it will return only fields with `api_list` group. It's allows to filter some data in list and make payload smaller.